### PR TITLE
feat: Implement audio merge functionality

### DIFF
--- a/ffmpeg4discord/__main__.py
+++ b/ffmpeg4discord/__main__.py
@@ -98,12 +98,17 @@ def main() -> None:
     args = arguments.get_args()
     web = args.pop("web")
     approx = args.pop("approx")
+    run_amerge = args.get("amerge")
+    args.pop("amerge", None)
 
     if web:
         port = args.pop("port")
 
     path = Path(args["filename"]).resolve()
+    
+    # twopass needs these values now for downmixing
     args["filename"] = path
+    args['amerge'] = run_amerge
 
     # instantiate the TwoPass class
     twopass = TwoPass(**args)
@@ -145,7 +150,21 @@ def main() -> None:
             # to loop or not to loop
             approx = bool(request.form.getlist("approx"))
 
+            # Get amerge state for this specific request
+            web_amerge = "amerge_audio" in request.form
+            # Set amerge flag on instance for this request
+            twopass.amerge = web_amerge
+
             twopass_loop(twopass=twopass, target_filesize=target_filesize, approx=approx)
+
+            # Conditionally run downmix
+            # Check if loop likely succeeded and merge requested
+            if twopass.output_filename and Path(twopass.output_filename).exists() and twopass.amerge:
+                twopass.downmix_audio()
+            elif twopass.amerge and (not twopass.output_filename or not Path(twopass.output_filename).exists()):
+                    # If merge requested but loop failed/file missing
+                    if twopass.message: twopass.message += " Downmix skipped."
+                    else: twopass.message = "Encoding failed. Downmix skipped."
 
             return render_template(
                 "web.html",
@@ -158,6 +177,17 @@ def main() -> None:
         app.run("0.0.0.0", port=port)
     else:
         twopass_loop(twopass=twopass, target_filesize=twopass.target_filesize, approx=approx)
+
+        # Conditionally run downmix
+        # Check if loop likely succeeded and merge requested via CLI flag
+        if twopass.output_filename and Path(twopass.output_filename).exists() and run_amerge:
+             twopass.downmix_audio()
+        elif run_amerge: # If merge was requested but loop failed/file missing
+             if twopass.message: # Append to existing message if possible
+                  twopass.message += " Downmix skipped."
+             else: # Set message if encoding failed silently
+                  twopass.message = "Encoding failed. Downmix skipped."
+
         print(twopass.message)
 
 

--- a/ffmpeg4discord/arguments.py
+++ b/ffmpeg4discord/arguments.py
@@ -132,6 +132,15 @@ def get_args() -> dict:
     )
     parser.add_argument("-p", "--port", type=int, help="Local port for the Flask application.")
 
+    # Add argument for audio merging
+    parser.add_argument(
+        "--amerge",
+        action=BooleanOptionalAction,
+        default=False,
+        help="Merge all audio channels down to 1 (mono) after encoding."
+    )
+
+
     args = vars(parser.parse_args())
 
     # fill in from the config JSON

--- a/ffmpeg4discord/templates/web.html
+++ b/ffmpeg4discord/templates/web.html
@@ -66,6 +66,14 @@
                 <div class="col">
                     <label for="audio_br" class="form-label">Audio Bitrate (kbps)</label>
                     <input class="form-control" name="audio_br" id="audio_br" type="text" value="{{ twopass.audio_br/1000 }}" />
+                    <div class="col">
+                        <div class="col">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="amerge_audio" value="True" name="amerge_audio">
+                                <label class="form-check-label" for="amerge_audio">Merge Audio</label>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="col">
                     <label for="crop" class="form-label">Crop</label>

--- a/ffmpeg4discord/twopass.py
+++ b/ffmpeg4discord/twopass.py
@@ -16,6 +16,7 @@ Functions:
 import logging
 import math
 import os
+import subprocess 
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
@@ -47,6 +48,7 @@ class TwoPass:
         resolution (str): Target resolution for the output video.
         config (str): Path to an optional configuration file for advanced ffmpeg settings.
         filename_times (bool): Flag to include timestamps in the output filename.
+        amerge (bool): Flag to enable audio downmixing post-encoding.
     """
 
     def __init__(
@@ -63,6 +65,7 @@ class TwoPass:
         verbose: bool = False,
         framerate: Optional[int] = None,
         vp9_opts: Optional[dict] = None,
+        amerge: bool = False, 
     ) -> None:
 
         self.target_filesize = target_filesize
@@ -79,6 +82,7 @@ class TwoPass:
         self.output_filesize = 0
         self.bitrate_dict = {}
         self.message = ""
+        self.amerge = amerge
 
         self.filename = filename
         self.fname = filename.name
@@ -357,6 +361,93 @@ class TwoPass:
 
         return self.output_filesize
 
+    def downmix_audio(self) -> bool:
+        """
+        Performs audio downmixing to mono on the already encoded output file using
+        a manually constructed command with subprocess.run() to ensure correct syntax.
+        This should be called *after* the `run()` method succeeds.
+
+        Replaces the original output file with the downmixed version if successful.
+        Updates `self.output_filesize` and `self.message`.
+
+        Returns:
+            bool: True if downmixing was successful or not needed/skipped, False otherwise.
+        """
+        
+        output_path = Path(self.output_filename)
+        audio_streams: list[dict] = []
+        num_audio_streams = 0
+        total_input_channels = 0
+        # Call ffprobe via ffmpeg-python to get stream info
+        intermediate_probe = ffmpeg.probe(str(output_path))
+        # Filter the streams to get only the audio ones
+        audio_streams = [s for s in intermediate_probe.get("streams", []) if s.get("codec_type") == "audio"]
+        # Count how many audio streams were found
+        num_audio_streams = len(audio_streams)
+        
+        # Loop through the found audio streams to count total channels
+        for stream in audio_streams:
+            total_input_channels += int(stream.get('channels', 0))
+
+        # Create a temporary filename for the downmixed output
+        temp_output_filename = str(output_path.with_name(output_path.stem + "_mono_temp" + output_path.suffix))
+        # Determine the target audio codec based on the video codec used
+        audio_codec = "aac" if self.codec == "libx264" else "libopus"
+        # Calculate the number of channels after amerge (should equal total_input_channels)
+        num_merged_channels = total_input_channels
+        # Calculate the coefficient for averaging all channels (1 / total channels)
+        coeff = 1.0 / num_merged_channels
+        # Create the coefficient string for the pan filter (e.g., "0.125*c0+0.125*c1+...+0.125*c7" for 8 channels)
+        pan_coeffs = "+".join([f"{coeff:.3f}*c{i}" for i in range(num_merged_channels)])
+        # Construct the full filter_complex string
+        filter_complex_str = f"[0:a]amerge=inputs={num_audio_streams}[a_merged];[a_merged]pan=1c|c0={pan_coeffs}[a_out]"
+        logging.info(f"Using filter_complex: {filter_complex_str}")
+
+        # Build the command as a list of strings
+        cmd = [
+            'ffmpeg',
+            # Input Option: Specifies the input file. `-i` is the flag, and `str(output_path)` is the path to the intermediate 
+            # video file created by the `run()` method.
+            '-i', str(output_path),
+            # Filter Option: The value `filter_complex_str` contains the string we built earlier 
+            # (e.g., "[0:a]amerge=inputs=4[a_merged];[a_merged]pan=mono|c0=0.125*c0+...+0.125*c7[a_out]") to merge and downmix the audio streams.
+            '-filter_complex', filter_complex_str,
+            # Map Option: Selects which video stream to include in the output. `0:v:0` means the first (0) video stream (`v`) from 
+            # the first input file (`0`).
+            '-map', '0:v:0',
+             # Map Option: Selects which audio stream to include in the output. `[a_out]` refers to the output label we defined at 
+             # the end of our `filter_complex` string, which contains the final merged and panned mono audio.
+            '-map', '[a_out]',
+            # Codec Option: Sets the video codec (`c:v`) to `copy`. This tells FFmpeg *not* to re-encode the video, but just to 
+            # copy the existing video data directly from the input to the output, which is much faster.
+            '-c:v', 'copy',
+            # Codec Option: Sets the audio codec (`c:a`) for the output audio stream. The `audio_codec` variable holds either `'aac'` or 
+            # `'libopus'` depending on the original video codec.
+            '-c:a', audio_codec,
+             # Option: Disables data stream recording. This prevents FFmpeg from trying to copy potentially incompatible data streams. Had issues 
+             # with timecode track `tmcd` and this fixed it
+            '-dn',
+            # Option: Finishes encoding when the shortest input stream ends. 
+            '-shortest',
+            # Global Option: Automatically overwrites the output file (`temp_output_filename`) if it already exists, without asking 
+            # for confirmation.
+            '-y',
+            #Give the output file name
+            temp_output_filename
+        ]
+        
+        # Execute the command using subprocess.run
+        subprocess.run(cmd, capture_output=True, text=True, check=True, encoding='utf-8')
+
+        # Replace the original file with the new temporary file
+        output_path.unlink()
+        os.rename(temp_output_filename, self.output_filename)
+
+        self.message = (
+                f"Encoding and mono downmix successful.) "
+                f"is located at {output_path.resolve()}"
+        )
+        return True
 
 def seconds_from_ts_string(ts_string: str) -> int:
     """


### PR DESCRIPTION
Add Audio Merge Feature

Adds a new --amerge command-line flag and corresponding web UI checkbox to allow merging all audio streams into a single mono channel after the main encoding process is complete. This uses an ffmpeg filter_complex (amerge + pan) for proper downmixing.